### PR TITLE
Asynchronous communication of message posting

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,4 +1,17 @@
 $(document).on('turbolinks:load',function(){
+  function buildHTML(message){
+    var image = (message.image !== null)? `<img src="${message.image}" class="content__message__image"></img>` : "" ;
+    var html = `<div class="message">
+                  <div class="message__upper">
+                    <div class="message__upper__user">${message.user_name}</div>
+                    <div class="message__upper__date">${message.created_at}</div>
+                  </div>
+                  <div class="message__lower">${message.content}</p>
+                    ${image}
+                  </div>
+                </div>`
+      return html;
+  }
   $('#new_message').on('submit',function(e){
     e.preventDefault();
     var formData = new FormData(this);
@@ -12,7 +25,9 @@ $(document).on('turbolinks:load',function(){
       contentType: false,
     })
     .done(function(data){
-      console.log(data);
+      var html = buildHTML(data);
+      $('.messages').append(html);
+      $('#new_message')[0].reset();
     })
     .fail(function(){
       console.log("失敗");

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,4 +1,4 @@
-$(document).on('turbolinks:load',function(){
+$(document).on('turbolinks:load', function(){
   function buildHTML(message){
     var image = (message.image !== null)? `<img src="${message.image}" class="content__message__image"></img>` : "" ;
     var html = `<div class="message">
@@ -13,7 +13,6 @@ $(document).on('turbolinks:load',function(){
       return html;
   }
   $('#new_message').on('submit',function(e){
-    e.preventDefault();
     var formData = new FormData(this);
     var send_url = $(this).attr('action');
     $.ajax({
@@ -27,10 +26,13 @@ $(document).on('turbolinks:load',function(){
     .done(function(data){
       var html = buildHTML(data);
       $('.messages').append(html);
+      var height = $('.messages')[0].scrollHeight;
+      $('.messages').animate({scrollTop:height});
       $('#new_message')[0].reset();
     })
     .fail(function(){
-      console.log("失敗");
+      alert('メッセージの送信に失敗しました。');
     })
+    return false;
   });
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,21 @@
+$(document).on('turbolinks:load',function(){
+  $('#new_message').on('submit',function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var send_url = $(this).attr('action');
+    $.ajax({
+      url: send_url,
+      type: 'POST',
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false,
+    })
+    .done(function(data){
+      console.log(data);
+    })
+    .fail(function(){
+      console.log("失敗");
+    })
+  });
+});

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,9 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      # redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,7 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      # redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,19 @@
+class UsersController < ApplicationController
+
+  def edit
+  end
+
+  def update
+    if current_user.update(user_params)
+      redirect_to root_path
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email)
+  end
+end

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.content @message.content
+json.user_name @message.user.name
+json.created_at @message.user.created_at.strftime("%Y/%m/%d %H:%M")
+json.image @message.image.url

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -4,14 +4,12 @@
     .header
       .left-header
         .group-name
-          グループ名
+          = @group.name
         %ul.group-members
           %li.member
-            メンバー名
-          %li.member
-            メンバー名
-          %li.member
-            メンバー名
+            Member:
+            - @group.users.each do |u|
+              = u.name
       .right-header
         = link_to  edit_group_path(@group) do
           .right-header__button edit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,9 +2,9 @@
 Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  root 'messages#index'
+  root 'groups#index'
   resources :users, only: [:index, :edit, :update]
-  resources :groups, only: [:new, :create, :edit, :update] do
+  resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
   end
 end

--- a/db/migrate/20190528154841_create_messages.rb
+++ b/db/migrate/20190528154841_create_messages.rb
@@ -4,7 +4,7 @@ class CreateMessages < ActiveRecord::Migration[5.0]
     create_table :messages do |t|
       t.string :content
       t.string :image
-      t.references :group, foregn_key: true
+      t.references :group, foreign_key: true
       t.references :user, foreign_key: true
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,5 +55,6 @@ ActiveRecord::Schema.define(version: 20190528154841) do
 
   add_foreign_key "group_users", "groups"
   add_foreign_key "group_users", "users"
+  add_foreign_key "messages", "groups"
   add_foreign_key "messages", "users"
 end


### PR DESCRIPTION
# メッセージの送信を非同期化する
1. メッセージがsubmitされた時にイベントを発火させる。
2. メッセージを送る先のurlとdataを変数に宣言。それらをajaxに入れる。
3. message controllerのcreateアクションにjson形式でデータを送信するように設定する。
4. 受けたjson形式のファイルを扱うためにcreate.json.jbuilderを作る。そしてそれを用いて、messageクラスのHTMLタグを生成するbuildHTMLを定義。それで生成したメッセージタグをmessagesに追加。
5. メッセージを追加した後には、フォームをリセットする。resetはjQueryメソッドではないので、getを用いてDOMオブジェクトに変更する必要があった。
6. scrollHightを用いて、messagesのスクロールで隠れているところも含めた高さをheightで取得。（これもDOMにする）。それを変数にscrollTopでページを移動する。
7. デフォルトでは２重送信防止の機能があり、連続してフォームが送信できないようになっている。submitイベントの返り値をfalseにしておくことで、連続してメッセージを送れるようにした。