### PR TITLE
Group creation screen formatting

### DIFF
--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -82,6 +82,7 @@ $(document).on('turbolinks:load',function(){
         $(newuser).parent().remove();
         } else {
           $(newuser).parent().remove();
+          alert('すでにこのユーザーは登録されています');
         }
       })
     }

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -31,6 +31,7 @@ $(document).on('turbolinks:load',function(){
       return result;
     }
     var preWord;
+    
     $('#user-search-field').on('keyup',function(){
     var input = $('#user-search-field').val();
     var inputs = input.split(" ").filter(function(a) { return a;});
@@ -46,13 +47,15 @@ $(document).on('turbolinks:load',function(){
       })
       .done(function(users) {
         $('#user-search-result').empty();
-        if (users.length !== 0) {
-          users.forEach(function(user){
-            appendUser(user);
-          });
-        }
-        else {
-          appendErrMsgToHTML('一致するユーザーはいません');
+        if (input.length !== 0){
+          if (users.length !== 0) {
+            users.forEach(function(user){
+              appendUser(user);
+            });
+          }
+          else {
+            appendErrMsgToHTML('一致するユーザーはいません');
+          }
         }
       })
       .fail(function(){
@@ -64,10 +67,24 @@ $(document).on('turbolinks:load',function(){
 
   $(document).on("click", ".user-search-add", function (){
     $('#chat-group-users').val();
-    var user_id = $(this).attr('data-user-id');
-    var user_name = $(this).attr('data-user-name');
-    addUser(user_id, user_name);
-    $(this).parent().remove();
+    var newuser = $(this);
+    var user_id = $(newuser).attr('data-user-id');
+    var user_name = $(newuser).attr('data-user-name');
+    var testuser = $('.chat-group-user.clearfix.js-chat-member');
+    if (testuser.length ==0) {
+      addUser(user_id, user_name);
+      $(newuser).parent().remove();
+    } else {
+      $(testuser).each(function(index, e) {
+        var id = $(e).attr('id');
+        if( user_id !== id ) {
+        addUser(user_id, user_name);
+        $(newuser).parent().remove();
+        } else {
+          $(newuser).parent().remove();
+        }
+      })
+    }
   });
 
   $(document).on("click", ".user-search-remove", function(){

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,5 +1,4 @@
 $(document).on('turbolinks:load',function(){
-  $('#user-search-field').on('keyup',function(){
     function appendUser(user) {
       var html = `<div class="chat-group-user clearfix">
                     <p class="chat-group-user__name">${user.name}</p>
@@ -15,21 +14,24 @@ $(document).on('turbolinks:load',function(){
       $('#user-search-result').append(html);
     }
 
-    function addUser(userId, userName){
+    function addUser(userId,userName) {
       var html = `<div id='chat-group-users'>
                     <div class='chat-group-user clearfix js-chat-member' id='${userId}'>
                       <input name='group[user_ids][]' type='hidden' value='${userId}'>
                         <p class='chat-group-user__name'>${userName}</p>
                         <a class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>削除</a>
-                      </div>`;
+                    </div>
+                  </div>`
       $('#chat-group-users').append(html);
     }
+
 
     function editElement(element){
       var result = '^'+element;
       return result;
     }
     var preWord;
+    $('#user-search-field').on('keyup',function(){
     var input = $('#user-search-field').val();
     var inputs = input.split(" ").filter(function(a) { return a;});
     var newInputs = inputs.map(editElement);
@@ -67,4 +69,8 @@ $(document).on('turbolinks:load',function(){
     addUser(user_id, user_name);
     $(this).parent().remove();
   });
+
+  $(document).on("click", ".user-search-remove", function(){
+    $(this).parent().remove();
+  })
 });

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,0 +1,50 @@
+$(document).on('turbolinks:load',function(){
+  $('#user-search-field').on('keyup',function(){
+    function appendUser(user) {
+      var html = `<div id = "chat-group-user-22">
+                    <p class="chat-group-user__name">${user.name}</p>
+                    <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.id}" data-user-name="${user.name}">追加</div>
+                  </div>`
+      $('#user-search-result').append(html);
+    }
+
+    function appendUser(user) {
+      
+    }
+
+
+    function editElement(element){
+      var result = '^'+element;
+      return result;
+    }
+    var preWord;
+    var input = $('#user-search-field').val();
+    var inputs = input.split(" ").filter(function(a) { return a;});
+    var newInputs = inputs.map(editElement);
+    var word = newInputs.join("|");
+    var reg = RegExp(word);
+    if (word != preWord){
+      $.ajax({
+        type: 'GET',
+        url: '/users',
+        data: { keyword: input},
+        dataType: 'json'
+      })
+      .done(function(users) {
+        $('#user-search-result').empty();
+        if (users.length !== 0) {
+          users.forEach(function(user){
+            appendUser(user);
+          });
+        }
+        else {
+          appendErrMsgToHTML('一致するユーザーはいません');
+        }
+      })
+      .fail(function(){
+        alert('検索に失敗しました');
+      })
+    }
+    preWord = word;
+    });
+});

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -82,7 +82,6 @@ $(document).on('turbolinks:load',function(){
         $(newuser).parent().remove();
         } else {
           $(newuser).parent().remove();
-          alert('すでにこのユーザーは登録されています');
         }
       })
     }

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -1,15 +1,18 @@
 $(document).on('turbolinks:load',function(){
   $('#user-search-field').on('keyup',function(){
     function appendUser(user) {
-      var html = `<div id = "chat-group-user-22">
+      var html = `<div class="chat-group-user clearfix">
                     <p class="chat-group-user__name">${user.name}</p>
                     <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.id}" data-user-name="${user.name}">追加</div>
                   </div>`
       $('#user-search-result').append(html);
     }
 
-    function appendUser(user) {
-      
+    function appendErrMsgToHTML(msg) {
+      var html = `<div class="chat-group-user clearfix>
+                    <p class="chat-group-user__name">${msg}</p>
+                  </div>`
+      $('#user-search-result').append(html);
     }
 
 
@@ -46,5 +49,5 @@ $(document).on('turbolinks:load',function(){
       })
     }
     preWord = word;
-    });
+  });
 });

--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -15,6 +15,15 @@ $(document).on('turbolinks:load',function(){
       $('#user-search-result').append(html);
     }
 
+    function addUser(userId, userName){
+      var html = `<div id='chat-group-users'>
+                    <div class='chat-group-user clearfix js-chat-member' id='${userId}'>
+                      <input name='group[user_ids][]' type='hidden' value='${userId}'>
+                        <p class='chat-group-user__name'>${userName}</p>
+                        <a class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>削除</a>
+                      </div>`;
+      $('#chat-group-users').append(html);
+    }
 
     function editElement(element){
       var result = '^'+element;
@@ -49,5 +58,13 @@ $(document).on('turbolinks:load',function(){
       })
     }
     preWord = word;
+  });
+
+  $(document).on("click", ".user-search-add", function (){
+    $('#chat-group-users').val();
+    var user_id = $(this).attr('data-user-id');
+    var user_name = $(this).attr('data-user-name');
+    addUser(user_id, user_name);
+    $(this).parent().remove();
   });
 });

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def index
-    @users = User.where('name LIKE(?)',"%#{params[:keyword]}%").where.not(id: current_user.id)
+    @users = User.where('name LIKE(?)',"%#{params[:keyword]}%").where.not(id: current_user)
     respond_to do |format|
       format.json
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def index
-    @users = User.where.not(id: current_user.id).where('name LIKE(?)',"%#{params[:keyword]}%")
+    @users = User.where('name LIKE(?)',"%#{params[:keyword]}%").where.not(id: current_user.id)
     respond_to do |format|
       format.json
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,10 @@
 class UsersController < ApplicationController
+  def index
+    @users = User.where.not(id: current_user.id).where('name LIKE(?)',"%#{params[:keyword]}%")
+    respond_to do |format|
+      format.json
+    end
+  end
 
   def edit
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,6 +20,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:id, :name, :email)
+    params.require(:user).permit(:name, :email)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,6 +20,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :email)
+    params.require(:user).permit(:id, :name, :email)
   end
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -12,10 +12,10 @@
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: "グループ名を入力してください"
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
-      %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+      %label.chat-group-form__label{for: "chat_group_チャットメンバーを追加"} チャットメンバーを追加
     .chat-group-form__field--right
       .chat-group-form__search.clearfix
-        %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+        %input#user-search-field.chat-group-form__input{placeholder: "追加したいユーザー名を入力してください", type: "text"}/
       #user-search-result
 
   .chat-group-form__field.clearfix
@@ -23,9 +23,6 @@
       %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
       #chat-group-users
-        -# #chat-group-user-22.chat-group-user.clearfix
-        -#   %input{:name => "chat_group[user_ids][]", :type => "hidden", :value => "22"}/
-        -#   %p.chat-group-user__name seo_kyohei
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -23,9 +23,9 @@
       %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
       #chat-group-users
-        #chat-group-user-22.chat-group-user.clearfix
-          %input{:name => "chat_group[user_ids][]", :type => "hidden", :value => "22"}/
-          %p.chat-group-user__name seo_kyohei
+        -# #chat-group-user-22.chat-group-user.clearfix
+        -#   %input{:name => "chat_group[user_ids][]", :type => "hidden", :value => "22"}/
+        -#   %p.chat-group-user__name seo_kyohei
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -11,31 +11,21 @@
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: "グループ名を入力してください"
   .chat-group-form__field.clearfix
-    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-    /
-      <div class='chat-group-form__field--left'>
-      <label class="chat-group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
-      </div>
-      <div class='chat-group-form__field--right'>
-      <div class='chat-group-form__search clearfix'>
-      <input class='chat-group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
-      </div>
-      <div id='user-search-result'></div>
-      </div>
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+    .chat-group-form__field--right
+      .chat-group-form__search.clearfix
+        %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+      #user-search-result
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-      /
-        <div id='chat-group-users'>
-        <div class='chat-group-user clearfix' id='chat-group-user-22'>
-        <input name='chat_group[user_ids][]' type='hidden' value='22'>
-        <p class='chat-group-user__name'>seo_kyohei</p>
-        </div>
-        </div>
+      #chat-group-users
+        #chat-group-user-22.chat-group-user.clearfix
+          %input{:name => "chat_group[user_ids][]", :type => "hidden", :value => "22"}/
+          %p.chat-group-user__name seo_kyohei
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+end


### PR DESCRIPTION
# グループ作成画面におけるインクリメントサーチ機能の実装
1. イベントを発火するビュー画面を整形した。
2. ユーザー検索のフォームに入力された時にイベントを発火させる。ここでは、空白のみのフォームは発火せず、また入力が変更された場合のみにイベントが発火するようにした。
3.  入力された文字列はuser_controllerに送られ、データベース内で一致するインスタンスがLIKE句で検索され、@usersという配列を作成。これをjson形式でjsファイルに返す。
4. 送信されたデータを用いるためにindex.json.jbuilderで配列を展開。
5. idがuser-search-resultのタグに、@usersの情報を元にグループに追加するユーザー名を表示。
6. 上で表示された候補から追加ボタンを押すと、ユーザーが追加されるaddUserが実行されるよう設定した。
（なお同じユーザーの登録を無効化するために、すでに追加されているユーザーのidをtestuserとして取得。それと追加を押したユーザーnewuserのidを比較して、分岐を作ってある。）
7. 追加した後に、削除を押すとclickイベントが発生して、グループから消えるようにした。

https://gyazo.com/80dfb14461914e4299f3c5d3468428d8