### PR TITLE
Add message id attribute

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -36,10 +36,32 @@ $(document).on('turbolinks:load', function(){
     return false;
   });
   
+
+
+  var reloadMessages = function() {
+    last_message_id = $('.message').eq(-1).attr('data-id');
+    reload_url_pattern = /messages/;
+    api_url = window.location.href.replace(reload_url_pattern,'api/messages');
+    $.ajax({
+      url: api_url,
+      type: "GET",
+      dataType: 'json',
+      data: { last_id: last_message_id },
+      processData: false,
+      contentType: false
+    })
+    .done(function(){
+      console.log('success');
+    })
+    .fail(function(){
+      console.log('fail');
+    })
+  }
+
   var interval = setInterval(function(){
-    console.log('check');
+    reloadMessages();
     // if () {
-    //   reloadMessage()
+    //   reloadMessages()
     // } else {
     //   clearInterval(interval);
     // }

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,7 +1,7 @@
 $(document).on('turbolinks:load', function(){
   function buildHTML(message){
     var image = (message.image !== null)? `<img src="${message.image}" class="content__message__image"></img>` : "" ;
-    var html = `<div class="message">
+    var html = `<div class="message" data-message-id='${message.id}'>
                   <div class="message__upper">
                     <div class="message__upper__user">${message.user_name}</div>
                     <div class="message__upper__date">${message.created_at}</div>

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -50,13 +50,21 @@ $(document).on('turbolinks:load', function(){
       processData: false,
       contentType: false
     })
-    .done(function(){
-      console.log('success');
+    .done(function(messages){
+      var insertHTML = '';
+      messages.forEach(function(message){
+        if(message.id > last_message_id) {
+          insertHTML += buildHTML(message);
+        }
+      })
+      $('.messages').append(insertHTML);
+      var height = $('.messages')[0].scrollHeight;
+      $('.messages').animate({scrollTop:height});
     })
     .fail(function(){
       console.log('fail');
     })
-  }
+  };
 
   var interval = setInterval(function(){
     reloadMessages();

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -35,4 +35,13 @@ $(document).on('turbolinks:load', function(){
     })
     return false;
   });
+  
+  var interval = setInterval(function(){
+    console.log('check');
+    // if () {
+    //   reloadMessage()
+    // } else {
+    //   clearInterval(interval);
+    // }
+  }, 5000 );
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -39,7 +39,7 @@ $(document).on('turbolinks:load', function(){
 
 
   var reloadMessages = function() {
-    last_message_id = $('.message').eq(-1).attr('data-id');
+    last_message_id = $('.message').eq(-1).data('id');
     reload_url_pattern = /messages/;
     api_url = window.location.href.replace(reload_url_pattern,'api/messages');
     $.ajax({

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -62,16 +62,17 @@ $(document).on('turbolinks:load', function(){
       $('.messages').animate({scrollTop:height});
     })
     .fail(function(){
-      console.log('fail');
+      alert('自動更新に失敗しました');
     })
   };
 
-  var interval = setInterval(function(){
+  var group_view_url_pattern = /\/groups\/\d+\/messages/;
+  var result = window.location.href.match(group_view_url_pattern);
+  var interval = setInterval(function() {
+  if (result){
     reloadMessages();
-    // if () {
-    //   reloadMessages()
-    // } else {
-    //   clearInterval(interval);
-    // }
-  }, 5000 );
+  }
+  else {
+    clearInterval(interval);
+  }} ,5000)
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,18 @@
+class Api::MessagesController < ApplicationController
+  before_action :set_group
+  def index
+    @message = Message.new
+    @messages = @group.messages.includes(:user).where("id > ?", "last_id")
+  end
+
+
+  private
+
+  def message_params
+    params.require(:message).permit(:content, :image).merge(user_id: current_user.id)
+  end
+
+  def set_group
+    @group = Group.find(params[:group_id])
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+ json.array! @messages do |message|
+  json.content message.content
+  json.image message.image
+  json.created_at message.created_at
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,3 +1,4 @@
+json.id @message.id
 json.content @message.content
 json.user_name @message.user.name
 json.created_at @message.user.created_at.strftime("%Y/%m/%d %H:%M")

--- a/app/views/messages/index.json.jbuilder
+++ b/app/views/messages/index.json.jbuilder
@@ -1,4 +1,0 @@
-json.array! @users do |user|
-  json.id user.id
-  json.name user.name
-end

--- a/app/views/messages/index.json.jbuilder
+++ b/app/views/messages/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# メッセージの自動更新機能
1. 自動更新のイベントをinterval = setInterval ... clearIntervalで設定。
2. コントローラにapiディレクトリを作成。そこのindexアクションにて、更新された分のメッセージを取得して@messagesという配列に入れる。ルーティングの設定も行う。
3. 先ほど取得したjson形式のメッセージたちを扱うためにindex.json.jbuilderを作成。
4. messageクラスの中で最後の要素をeq(-1)で取得し、そのidをlast_message_idとして、先ほど作成したindexコントローラに送信する。
5. messagesクラスに取得したメッセージを追加。またスクロールできる範囲の高さを取得して、そこまで移動するように設定した。
6. group/group_id/messagesでのみ更新を行うように、正規表現を使って制限する。

# 自動更新の様子
https://gyazo.com/73f1fa4554dfda5b2a20887aa0da6fdc